### PR TITLE
Fix background flash

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18,6 +18,10 @@
     }
   }
 
+  body {
+    @apply bg-white dark:bg-slate-900;
+  }
+
   /* override a few @tailwindcss/typography styles */
   /* prevent adding backticks to code excerpts */
   /* .prose code::before,


### PR DESCRIPTION
Add background color to avoid a white flashing background in dark mode when scrolling quickly.

Fixes #65