### PR TITLE
Fix huddle live demo url

### DIFF
--- a/content/portfolio/portfolioItems.json
+++ b/content/portfolio/portfolioItems.json
@@ -555,7 +555,7 @@
   {
     "title": "Huddle Landing Page",
     "description": "A demo landing page for a fictional software company. Built with Gatsby and Tailwind CSS, and deployed with Netlify.",
-    "url": "https://jonrutter-huddle-landing-page.netlify.app/",
+    "url": "https://jonrutter-huddle.vercel.app/",
     "code": "https://github.com/jonrutter/huddle-demo",
     "type": "website",
     "featured": false,

--- a/content/portfolio/portfolioItems.ts
+++ b/content/portfolio/portfolioItems.ts
@@ -175,7 +175,7 @@ export const portfolioItems: DraftPortfolioItemType[] = [
     title: 'Huddle Landing Page',
     description:
       'A demo landing page for a fictional software company. Built with Gatsby and Tailwind CSS, and deployed with Netlify.',
-    url: 'https://jonrutter-huddle-landing-page.netlify.app/',
+    url: 'https://jonrutter-huddle.vercel.app/',
     code: 'https://github.com/jonrutter/huddle-demo',
     type: 'website',
     featured: false,


### PR DESCRIPTION
Update url to live demo of huddle project, after migrating to Vercel.